### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -2,7 +2,10 @@ name: Validation
 on:
   pull_request:
     branches: [ main ]
-    
+
+permissions:
+  contents: read
+
 jobs:
   validation:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/zyofeng/serilog-redaction/security/code-scanning/1](https://github.com/zyofeng/serilog-redaction/security/code-scanning/1)

To fix this, add an explicit `permissions` block to the workflow so the token is constrained regardless of repo/org defaults.

Best approach here: define workflow-level permissions right after the `on` section, since there is only one job and no special write needs are shown. Use the minimal permission recommended by CodeQL:

- `contents: read`

File to change:
- `.github/workflows/validation.yml`  
Add:
```yml
permissions:
  contents: read
```
between the trigger definition and `jobs:`.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
